### PR TITLE
Improve label focus animation

### DIFF
--- a/src/components/label.vue
+++ b/src/components/label.vue
@@ -1,13 +1,15 @@
 <template>
     <label v-if="! automated()"
            :class="filled ? small : (focus ? small : large)"
-           style="width: calc(100% - 19px); transition: all 0.1s ease, background-color 0s"
+           style="width: calc(100% - 19px); transition: all 0.15s ease, background-color 0s"
            class="varnish-label varnish-font bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 flex items-center cursor-text select-none pointer-events-none absolute top-[1px] left-1">
 
         <!-- Icon -->
-        <i :class="icon"
-           v-if="! filled && ! focus && icon"
-           class="varnish-icon w-[31px] min-w-[31px] max-w-[31px] text-[14px] text-gray-500/[.40] dark:text-gray-500/[.50] text-center relative top-[.5px] mr-[6px]">
+        <i :class="[icon, {
+            'w-[31px] min-w-[31px]': ! filled && ! focus && icon,
+            'w-0 opacity-0 -translate-x-2 -translate-y-1': !(! filled && ! focus && icon),
+        }]"
+           class="varnish-icon max-w-[31px] text-[14px] text-gray-500/[.40] dark:text-gray-500/[.50] text-center relative top-[.5px] mr-[6px] transition-all duration-150">
         </i>
 
         <!-- Value -->


### PR DESCRIPTION
Hey,

I saw the label animation on the input components had a jumpy animation and I thought maybe there is room to improve it.
Here is my attempt, let me know what you think 😄

Before:
![varnish-label-animation-before](https://user-images.githubusercontent.com/15275787/184684158-73c63e05-e233-403d-8a44-a03f7ef9b815.gif)

After:
![varnish-label-animation-after](https://user-images.githubusercontent.com/15275787/184684171-d4e13551-2de1-40f1-a96f-3a7dec00a7e7.gif)

I also increased the transition duration by 50ms so the eye can notice the animation happening, since it was too fast.