### PR TITLE
Add ease to switch componet's toggle animation

### DIFF
--- a/src/components/switch.vue
+++ b/src/components/switch.vue
@@ -20,7 +20,7 @@
                     :id="`toggle-${name}`"
                     @click.prevent="change(active ? 0 : 1)"
                     class="varnish-toggle w-[60px] h-[31px] relative transition-all duration-200 rounded-full cursor-pointer
-                           after:h-[25px] after:w-[25px] after:bg-white after:absolute after:transition-all after:duration-200 after:top-[3px] after:rounded-full"
+                           after:h-[25px] after:w-[25px] after:bg-white after:absolute after:transition-all after:duration-300 after:ease-out after:top-[3px] after:rounded-full"
                     :class="active ? 'varnish-active after:left-[32px] bg-emerald-600/[.80] dark:bg-emerald-600' : 'after:left-[3px] bg-gray-400/[.45] dark:bg-gray-700'">
             </button>
 


### PR DESCRIPTION
This simply adds an ease to make the toggle animation feel more natural and less linear.

Before:
![varnish-switch-animation-before](https://user-images.githubusercontent.com/15275787/184689499-057d00ec-7ca4-4f5a-aa99-9f90b49bcf5b.gif)

After:
![varnish-switch-animation-after](https://user-images.githubusercontent.com/15275787/184689612-ff26dcd9-9fc5-43c0-b7c0-7d6f222c4c99.gif)

Note that even though I recorded these before/after gifs in 60fps, they may not be an accurate representation of the animation and obviously are not good as the browser live demo. So I suggest to see it in action ;)
