### PR TITLE
Improve badge padding and colors

### DIFF
--- a/src/components/badge.vue
+++ b/src/components/badge.vue
@@ -5,7 +5,7 @@
 
         <!-- Content -->
         <div :class="[modes[mode][color], uppercase ? 'uppercase' : '']"
-             class="varnish-content inline-block rounded-full font-semibold text-[11px] select-none whitespace-nowrap px-[10px] py-[4.5px] pb-1">
+             class="varnish-content inline-block rounded-full font-semibold text-[11px] select-none whitespace-nowrap px-[10px] pt-[.3rem] pb-1">
 
             <!-- Text -->
             {{ value }}
@@ -35,20 +35,20 @@
         data() { return {
             modes : {
                 opaque : {
-                    blue   : 'bg-sky-500/[.15] dark:bg-sky-700 text-sky-700/[.90] dark:text-sky-200',
-                    green  : 'bg-emerald-500/[.15] dark:bg-emerald-700 text-emerald-700/[.90] dark:text-emerald-200',
-                    gray   : 'bg-gray-500/[.10] dark:bg-gray-700 text-gray-700/[.90] dark:text-gray-200',
-                    purple : 'bg-purple-500/[.15] dark:bg-purple-700 text-purple-900/[.70] dark:text-purple-200',
-                    red    : 'bg-red-500/[.15] dark:bg-red-700 text-red-800/[.90] dark:text-red-200',
-                    yellow : 'bg-yellow-500/[.15] dark:bg-yellow-700 text-yellow-700/[.90] dark:text-yellow-200',
+                    blue   : 'bg-sky-500/[.15] dark:bg-sky-700 text-sky-700/80 dark:text-sky-200',
+                    green  : 'bg-emerald-500/[.15] dark:bg-emerald-700 text-emerald-700/80 dark:text-emerald-200',
+                    gray   : 'bg-gray-500/10 dark:bg-gray-700 text-gray-700/80 dark:text-gray-200',
+                    purple : 'bg-purple-500/[.15] dark:bg-purple-700 text-purple-900/70 dark:text-purple-200',
+                    red    : 'bg-red-500/[.15] dark:bg-red-700 text-red-800/80 dark:text-red-200',
+                    yellow : 'bg-yellow-500/[.15] dark:bg-yellow-600 text-yellow-700/80 dark:text-yellow-100',
                 },
                 transparent : {
                     blue   : 'bg-transparent text-sky-600 dark:text-sky-400',
                     green  : 'bg-transparent text-emerald-600 dark:text-emerald-400',
-                    gray   : 'bg-transparent text-gray-600 dark:text-gray-400',
-                    purple : 'bg-transparent text-purple-700 dark:text-purple-400',
-                    red    : 'bg-transparent text-red-700 dark:text-red-400',
-                    yellow : 'bg-transparent text-yellow-700 dark:text-yellow-400',
+                    gray   : 'bg-transparent text-gray-500 dark:text-gray-400',
+                    purple : 'bg-transparent text-purple-600 dark:text-purple-400',
+                    red    : 'bg-transparent text-red-600 dark:text-red-400',
+                    yellow : 'bg-transparent text-yellow-600 dark:text-yellow-400',
                 }
             }
         }},


### PR DESCRIPTION
I noticed the badge padding were uneven so I tried to improve that, plus I tried to make some of the colors less saturated to make it more consistent across the board.

Light mode
---
Before:
<img width="173" alt="image" src="https://user-images.githubusercontent.com/15275787/184697220-75adc9f8-e16e-49ac-9deb-df31baed81a7.png">
After:
<img width="173" alt="image" src="https://user-images.githubusercontent.com/15275787/184697376-4f90c7f0-0245-47bf-b604-5e7712950576.png">

Dark mode
---
Before:
<img width="173" alt="image" src="https://user-images.githubusercontent.com/15275787/184697971-51b27b81-9d3c-419a-afd3-34fdbb424f48.png">
After:
<img width="173" alt="image" src="https://user-images.githubusercontent.com/15275787/184698001-8e924ccd-dcba-4684-9b07-98e02f45b940.png">
